### PR TITLE
Add complete REST API endpoints and admin configuration

### DIFF
--- a/backend/accounts/admin.py
+++ b/backend/accounts/admin.py
@@ -1,3 +1,19 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+from .models import Employee
 
-# Register your models here.
+
+@admin.register(Employee)
+class EmployeeAdmin(UserAdmin):
+    list_display = ('username', 'email', 'first_name', 'last_name', 'role', 'store', 'is_active')
+    list_filter = ('role', 'is_active', 'store')
+    search_fields = ('username', 'email', 'first_name', 'last_name')
+    ordering = ('username',)
+
+    fieldsets = UserAdmin.fieldsets + (
+        ('Employee Info', {'fields': ('role', 'store')}),
+    )
+
+    add_fieldsets = UserAdmin.add_fieldsets + (
+        ('Employee Info', {'fields': ('role', 'store')}),
+    )

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -35,6 +35,7 @@ INSTALLED_APPS = [
     # Third party apps
     'rest_framework',
     'rest_framework_simplejwt',
+    'rest_framework_simplejwt.token_blacklist',
     'corsheaders',
     'django_filters',
     

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -15,8 +15,39 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+
+from products.views import ProductViewSet, SKUViewSet
+from inventory.views import StoreViewSet, RegisterViewSet, StockLevelViewSet, StockMovementViewSet
+from sales.views import SaleViewSet, ReturnViewSet
+from suppliers.views import SupplierViewSet, PurchaseOrderViewSet, PurchaseOrderLineViewSet
+
+# Create a router and register ViewSets
+router = DefaultRouter()
+
+# Products
+router.register(r'products', ProductViewSet, basename='product')
+router.register(r'skus', SKUViewSet, basename='sku')
+
+# Inventory
+router.register(r'stores', StoreViewSet, basename='store')
+router.register(r'registers', RegisterViewSet, basename='register')
+router.register(r'stock-levels', StockLevelViewSet, basename='stocklevel')
+router.register(r'stock-movements', StockMovementViewSet, basename='stockmovement')
+
+# Sales
+router.register(r'sales', SaleViewSet, basename='sale')
+router.register(r'returns', ReturnViewSet, basename='return')
+
+# Suppliers
+router.register(r'suppliers', SupplierViewSet, basename='supplier')
+router.register(r'purchase-orders', PurchaseOrderViewSet, basename='purchaseorder')
+router.register(r'purchase-order-lines', PurchaseOrderLineViewSet, basename='purchaseorderline')
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/", include(router.urls)),
+    path("api/", include("accounts.urls")),
+    path("api/reports/", include("reports.urls")),
 ]

--- a/backend/inventory/admin.py
+++ b/backend/inventory/admin.py
@@ -1,3 +1,47 @@
 from django.contrib import admin
+from .models import Store, Register, StockLevel, StockMovement
 
-# Register your models here.
+
+class RegisterInline(admin.TabularInline):
+    model = Register
+    extra = 1
+
+
+@admin.register(Store)
+class StoreAdmin(admin.ModelAdmin):
+    list_display = ('name', 'location', 'register_count')
+    search_fields = ('name', 'location')
+    inlines = [RegisterInline]
+
+    def register_count(self, obj):
+        return obj.registers.count()
+    register_count.short_description = 'Registers'
+
+
+@admin.register(Register)
+class RegisterAdmin(admin.ModelAdmin):
+    list_display = ('identifier', 'store')
+    list_filter = ('store',)
+    search_fields = ('identifier', 'store__name')
+
+
+@admin.register(StockLevel)
+class StockLevelAdmin(admin.ModelAdmin):
+    list_display = ('store', 'sku', 'quantity', 'is_low_stock')
+    list_filter = ('store',)
+    search_fields = ('store__name', 'sku__sku_code', 'sku__product__name')
+    ordering = ('store', 'sku')
+
+    def is_low_stock(self, obj):
+        return obj.quantity <= 10
+    is_low_stock.boolean = True
+    is_low_stock.short_description = 'Low Stock'
+
+
+@admin.register(StockMovement)
+class StockMovementAdmin(admin.ModelAdmin):
+    list_display = ('timestamp', 'stock_level', 'movement_type', 'quantity_changed')
+    list_filter = ('movement_type', 'timestamp')
+    search_fields = ('stock_level__sku__sku_code', 'stock_level__store__name')
+    ordering = ('-timestamp',)
+    readonly_fields = ('timestamp',)

--- a/backend/products/admin.py
+++ b/backend/products/admin.py
@@ -1,3 +1,27 @@
 from django.contrib import admin
+from .models import Product, SKU
 
-# Register your models here.
+
+class SKUInline(admin.TabularInline):
+    model = SKU
+    extra = 1
+
+
+@admin.register(Product)
+class ProductAdmin(admin.ModelAdmin):
+    list_display = ('name', 'description', 'created_at', 'sku_count')
+    search_fields = ('name', 'description')
+    ordering = ('-created_at',)
+    inlines = [SKUInline]
+
+    def sku_count(self, obj):
+        return obj.skus.count()
+    sku_count.short_description = 'SKUs'
+
+
+@admin.register(SKU)
+class SKUAdmin(admin.ModelAdmin):
+    list_display = ('sku_code', 'product', 'barcode', 'base_price')
+    list_filter = ('product',)
+    search_fields = ('sku_code', 'barcode', 'product__name')
+    ordering = ('sku_code',)

--- a/backend/products/views.py
+++ b/backend/products/views.py
@@ -3,47 +3,35 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from django_filters.rest_framework import DjangoFilterBackend
 
-from .models import Product, Category
-from .serializers import ProductSerializer, CategorySerializer
+from .models import Product, SKU
+from .serializers import ProductSerializer, SKUSerializer
 from accounts.permissions import IsManagerOrReadOnly
 
 
 class ProductViewSet(viewsets.ModelViewSet):
     """
     API endpoint for products.
-    
+
     Permissions:
     - Managers: Can create, update, delete products
     - Cashiers: Can only view products
     """
     queryset = Product.objects.all()
     serializer_class = ProductSerializer
-    permission_classes = [IsManagerOrReadOnly]  # Role-based permission
+    permission_classes = [IsManagerOrReadOnly]
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
-    filterset_fields = ['category', 'is_active']
-    search_fields = ['name', 'sku', 'barcode']
-    ordering_fields = ['name', 'price', 'created_at']
+    search_fields = ['name', 'description']
+    ordering_fields = ['name', 'created_at']
     ordering = ['-created_at']
-    
-    def perform_create(self, serializer):
-        # Auto-set created_by to current user
-        serializer.save(created_by=self.request.user)
-    
-    @action(detail=False, methods=['get'])
-    def low_stock(self, request):
-        """Get products with low stock (any authenticated user)"""
-        low_stock_products = Product.objects.filter(
-            stock_quantity__lte=10
-        )
-        serializer = self.get_serializer(low_stock_products, many=True)
-        return Response(serializer.data)
 
 
-class CategoryViewSet(viewsets.ModelViewSet):
+class SKUViewSet(viewsets.ModelViewSet):
     """
-    API endpoint for categories.
-    Same permissions as products.
+    API endpoint for SKUs.
     """
-    queryset = Category.objects.all()
-    serializer_class = CategorySerializer
-    permission_classes = [IsManagerOrReadOnly]  # Role-based permission
+    queryset = SKU.objects.all().select_related('product')
+    serializer_class = SKUSerializer
+    permission_classes = [IsManagerOrReadOnly]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter]
+    filterset_fields = ['product']
+    search_fields = ['sku_code', 'barcode', 'product__name']

--- a/backend/reports/serializers.py
+++ b/backend/reports/serializers.py
@@ -1,0 +1,107 @@
+from rest_framework import serializers
+from sales.models import Sale, SaleLine
+from products.models import Product, SKU
+from inventory.models import Store, StockLevel
+from accounts.models import Employee
+
+
+class SalesSummarySerializer(serializers.Serializer):
+    """Serializer for sales summary data."""
+    period = serializers.CharField()
+    start_date = serializers.DateTimeField()
+    end_date = serializers.DateTimeField()
+    total_sales = serializers.IntegerField()
+    total_revenue = serializers.DecimalField(max_digits=12, decimal_places=2)
+    total_items_sold = serializers.IntegerField()
+    average_sale = serializers.DecimalField(max_digits=10, decimal_places=2)
+
+
+class DailySalesSerializer(serializers.Serializer):
+    """Serializer for daily sales breakdown."""
+    date = serializers.DateField()
+    total_sales = serializers.IntegerField()
+    total_revenue = serializers.DecimalField(max_digits=12, decimal_places=2)
+    total_items = serializers.IntegerField()
+
+
+class TopProductSerializer(serializers.Serializer):
+    """Serializer for top selling products."""
+    product_id = serializers.IntegerField()
+    product_name = serializers.CharField()
+    total_quantity = serializers.IntegerField()
+    total_revenue = serializers.DecimalField(max_digits=12, decimal_places=2)
+    transaction_count = serializers.IntegerField()
+
+
+class SalesByStoreSerializer(serializers.Serializer):
+    """Serializer for sales by store."""
+    store_id = serializers.IntegerField()
+    store_name = serializers.CharField()
+    total_sales = serializers.IntegerField()
+    total_revenue = serializers.DecimalField(max_digits=12, decimal_places=2)
+    average_sale = serializers.DecimalField(max_digits=10, decimal_places=2)
+
+
+class SalesByEmployeeSerializer(serializers.Serializer):
+    """Serializer for sales by employee."""
+    employee_id = serializers.IntegerField()
+    employee_name = serializers.CharField()
+    role = serializers.CharField()
+    total_sales = serializers.IntegerField()
+    total_revenue = serializers.DecimalField(max_digits=12, decimal_places=2)
+    average_sale = serializers.DecimalField(max_digits=10, decimal_places=2)
+
+
+class SalesByPaymentMethodSerializer(serializers.Serializer):
+    """Serializer for sales by payment method."""
+    payment_method = serializers.CharField()
+    total_sales = serializers.IntegerField()
+    total_revenue = serializers.DecimalField(max_digits=12, decimal_places=2)
+    percentage = serializers.DecimalField(max_digits=5, decimal_places=2)
+
+
+class InventoryValueSerializer(serializers.Serializer):
+    """Serializer for inventory valuation."""
+    store_id = serializers.IntegerField()
+    store_name = serializers.CharField()
+    total_items = serializers.IntegerField()
+    total_skus = serializers.IntegerField()
+    total_value = serializers.DecimalField(max_digits=12, decimal_places=2)
+
+
+class InventoryItemSerializer(serializers.Serializer):
+    """Serializer for individual inventory items."""
+    sku_id = serializers.IntegerField()
+    sku_code = serializers.CharField()
+    product_name = serializers.CharField()
+    store_name = serializers.CharField()
+    quantity = serializers.IntegerField()
+    unit_price = serializers.DecimalField(max_digits=10, decimal_places=2)
+    total_value = serializers.DecimalField(max_digits=12, decimal_places=2)
+
+
+class LowStockAlertSerializer(serializers.Serializer):
+    """Serializer for low stock alerts."""
+    sku_id = serializers.IntegerField()
+    sku_code = serializers.CharField()
+    product_name = serializers.CharField()
+    store_id = serializers.IntegerField()
+    store_name = serializers.CharField()
+    current_quantity = serializers.IntegerField()
+    threshold = serializers.IntegerField()
+    status = serializers.CharField()  # LOW, CRITICAL, OUT_OF_STOCK
+
+
+class StockMovementReportSerializer(serializers.Serializer):
+    """Serializer for stock movement report."""
+    date = serializers.DateField()
+    movement_type = serializers.CharField()
+    total_movements = serializers.IntegerField()
+    total_quantity = serializers.IntegerField()
+
+
+class HourlySalesSerializer(serializers.Serializer):
+    """Serializer for hourly sales breakdown."""
+    hour = serializers.IntegerField()
+    total_sales = serializers.IntegerField()
+    total_revenue = serializers.DecimalField(max_digits=12, decimal_places=2)

--- a/backend/reports/urls.py
+++ b/backend/reports/urls.py
@@ -1,0 +1,39 @@
+from django.urls import path
+from .views import (
+    SalesSummaryView,
+    DailySalesView,
+    HourlySalesView,
+    TopProductsView,
+    SalesByStoreView,
+    SalesByEmployeeView,
+    SalesByPaymentMethodView,
+    InventoryValueView,
+    InventoryDetailView,
+    LowStockReportView,
+    StockMovementReportView,
+    DashboardView,
+)
+
+app_name = 'reports'
+
+urlpatterns = [
+    # Dashboard
+    path('dashboard/', DashboardView.as_view(), name='dashboard'),
+
+    # Sales Reports
+    path('sales/summary/', SalesSummaryView.as_view(), name='sales_summary'),
+    path('sales/daily/', DailySalesView.as_view(), name='daily_sales'),
+    path('sales/hourly/', HourlySalesView.as_view(), name='hourly_sales'),
+    path('sales/by-store/', SalesByStoreView.as_view(), name='sales_by_store'),
+    path('sales/by-employee/', SalesByEmployeeView.as_view(), name='sales_by_employee'),
+    path('sales/by-payment-method/', SalesByPaymentMethodView.as_view(), name='sales_by_payment_method'),
+
+    # Product Reports
+    path('products/top-selling/', TopProductsView.as_view(), name='top_products'),
+
+    # Inventory Reports
+    path('inventory/value/', InventoryValueView.as_view(), name='inventory_value'),
+    path('inventory/detail/', InventoryDetailView.as_view(), name='inventory_detail'),
+    path('inventory/low-stock/', LowStockReportView.as_view(), name='low_stock'),
+    path('inventory/movements/', StockMovementReportView.as_view(), name='stock_movements'),
+]

--- a/backend/reports/views.py
+++ b/backend/reports/views.py
@@ -1,0 +1,548 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from django.db.models import Sum, Count, Avg, F, DecimalField
+from django.db.models.functions import TruncDate, TruncHour, Coalesce
+from django.utils import timezone
+from datetime import timedelta
+from decimal import Decimal
+
+from sales.models import Sale, SaleLine
+from products.models import Product, SKU
+from inventory.models import Store, StockLevel, StockMovement
+from accounts.models import Employee
+from .serializers import (
+    SalesSummarySerializer,
+    DailySalesSerializer,
+    TopProductSerializer,
+    SalesByStoreSerializer,
+    SalesByEmployeeSerializer,
+    SalesByPaymentMethodSerializer,
+    InventoryValueSerializer,
+    InventoryItemSerializer,
+    LowStockAlertSerializer,
+    StockMovementReportSerializer,
+    HourlySalesSerializer,
+)
+
+
+class SalesSummaryView(APIView):
+    """
+    Sales summary report.
+
+    Query params:
+    - period: 'today', 'week', 'month', 'year', 'custom'
+    - start_date: Required if period is 'custom'
+    - end_date: Required if period is 'custom'
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        period = request.query_params.get('period', 'today')
+        now = timezone.now()
+
+        # Determine date range based on period
+        if period == 'today':
+            start_date = now.replace(hour=0, minute=0, second=0, microsecond=0)
+            end_date = now
+        elif period == 'week':
+            start_date = now - timedelta(days=7)
+            end_date = now
+        elif period == 'month':
+            start_date = now - timedelta(days=30)
+            end_date = now
+        elif period == 'year':
+            start_date = now - timedelta(days=365)
+            end_date = now
+        elif period == 'custom':
+            start_date = request.query_params.get('start_date')
+            end_date = request.query_params.get('end_date')
+            if not start_date or not end_date:
+                return Response({'error': 'start_date and end_date required for custom period'}, status=400)
+        else:
+            return Response({'error': 'Invalid period'}, status=400)
+
+        # Query sales
+        sales = Sale.objects.filter(created_at__gte=start_date, created_at__lte=end_date)
+
+        total_sales = sales.count()
+        total_revenue = sales.aggregate(total=Coalesce(Sum('total_amount'), Decimal('0')))['total']
+
+        # Get total items sold
+        total_items = SaleLine.objects.filter(
+            sale__in=sales
+        ).aggregate(total=Coalesce(Sum('quantity'), 0))['total']
+
+        average_sale = total_revenue / total_sales if total_sales > 0 else Decimal('0')
+
+        data = {
+            'period': period,
+            'start_date': start_date,
+            'end_date': end_date,
+            'total_sales': total_sales,
+            'total_revenue': total_revenue,
+            'total_items_sold': total_items,
+            'average_sale': average_sale,
+        }
+
+        serializer = SalesSummarySerializer(data)
+        return Response(serializer.data)
+
+
+class DailySalesView(APIView):
+    """
+    Daily sales breakdown for a date range.
+
+    Query params:
+    - days: Number of days to look back (default: 7)
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        days = int(request.query_params.get('days', 7))
+        start_date = timezone.now() - timedelta(days=days)
+
+        daily_sales = Sale.objects.filter(
+            created_at__gte=start_date
+        ).annotate(
+            date=TruncDate('created_at')
+        ).values('date').annotate(
+            total_sales=Count('id'),
+            total_revenue=Sum('total_amount'),
+        ).order_by('date')
+
+        # Get items sold per day
+        result = []
+        for day in daily_sales:
+            items = SaleLine.objects.filter(
+                sale__created_at__date=day['date']
+            ).aggregate(total=Coalesce(Sum('quantity'), 0))['total']
+
+            result.append({
+                'date': day['date'],
+                'total_sales': day['total_sales'],
+                'total_revenue': day['total_revenue'] or Decimal('0'),
+                'total_items': items,
+            })
+
+        serializer = DailySalesSerializer(result, many=True)
+        return Response(serializer.data)
+
+
+class HourlySalesView(APIView):
+    """
+    Hourly sales breakdown for today.
+    Useful for identifying peak hours.
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        today_start = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
+
+        hourly_sales = Sale.objects.filter(
+            created_at__gte=today_start
+        ).annotate(
+            hour=TruncHour('created_at')
+        ).values('hour').annotate(
+            total_sales=Count('id'),
+            total_revenue=Sum('total_amount'),
+        ).order_by('hour')
+
+        result = []
+        for entry in hourly_sales:
+            result.append({
+                'hour': entry['hour'].hour if entry['hour'] else 0,
+                'total_sales': entry['total_sales'],
+                'total_revenue': entry['total_revenue'] or Decimal('0'),
+            })
+
+        serializer = HourlySalesSerializer(result, many=True)
+        return Response(serializer.data)
+
+
+class TopProductsView(APIView):
+    """
+    Top selling products report.
+
+    Query params:
+    - days: Number of days to look back (default: 30)
+    - limit: Number of products to return (default: 10)
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        days = int(request.query_params.get('days', 30))
+        limit = int(request.query_params.get('limit', 10))
+        start_date = timezone.now() - timedelta(days=days)
+
+        top_products = SaleLine.objects.filter(
+            sale__created_at__gte=start_date
+        ).values(
+            'sku__product__id',
+            'sku__product__name'
+        ).annotate(
+            total_quantity=Sum('quantity'),
+            total_revenue=Sum(F('quantity') * F('unit_price'), output_field=DecimalField()),
+            transaction_count=Count('sale', distinct=True)
+        ).order_by('-total_quantity')[:limit]
+
+        result = []
+        for product in top_products:
+            result.append({
+                'product_id': product['sku__product__id'],
+                'product_name': product['sku__product__name'],
+                'total_quantity': product['total_quantity'],
+                'total_revenue': product['total_revenue'] or Decimal('0'),
+                'transaction_count': product['transaction_count'],
+            })
+
+        serializer = TopProductSerializer(result, many=True)
+        return Response(serializer.data)
+
+
+class SalesByStoreView(APIView):
+    """
+    Sales breakdown by store.
+
+    Query params:
+    - days: Number of days to look back (default: 30)
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        days = int(request.query_params.get('days', 30))
+        start_date = timezone.now() - timedelta(days=days)
+
+        sales_by_store = Sale.objects.filter(
+            created_at__gte=start_date
+        ).values(
+            'store__id',
+            'store__name'
+        ).annotate(
+            total_sales=Count('id'),
+            total_revenue=Sum('total_amount'),
+            average_sale=Avg('total_amount')
+        ).order_by('-total_revenue')
+
+        result = []
+        for store in sales_by_store:
+            result.append({
+                'store_id': store['store__id'],
+                'store_name': store['store__name'],
+                'total_sales': store['total_sales'],
+                'total_revenue': store['total_revenue'] or Decimal('0'),
+                'average_sale': store['average_sale'] or Decimal('0'),
+            })
+
+        serializer = SalesByStoreSerializer(result, many=True)
+        return Response(serializer.data)
+
+
+class SalesByEmployeeView(APIView):
+    """
+    Sales breakdown by employee/cashier.
+
+    Query params:
+    - days: Number of days to look back (default: 30)
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        days = int(request.query_params.get('days', 30))
+        start_date = timezone.now() - timedelta(days=days)
+
+        sales_by_employee = Sale.objects.filter(
+            created_at__gte=start_date
+        ).values(
+            'cashier__id',
+            'cashier__first_name',
+            'cashier__last_name',
+            'cashier__role'
+        ).annotate(
+            total_sales=Count('id'),
+            total_revenue=Sum('total_amount'),
+            average_sale=Avg('total_amount')
+        ).order_by('-total_revenue')
+
+        result = []
+        for emp in sales_by_employee:
+            result.append({
+                'employee_id': emp['cashier__id'],
+                'employee_name': f"{emp['cashier__first_name']} {emp['cashier__last_name']}",
+                'role': emp['cashier__role'],
+                'total_sales': emp['total_sales'],
+                'total_revenue': emp['total_revenue'] or Decimal('0'),
+                'average_sale': emp['average_sale'] or Decimal('0'),
+            })
+
+        serializer = SalesByEmployeeSerializer(result, many=True)
+        return Response(serializer.data)
+
+
+class SalesByPaymentMethodView(APIView):
+    """
+    Sales breakdown by payment method.
+
+    Query params:
+    - days: Number of days to look back (default: 30)
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        days = int(request.query_params.get('days', 30))
+        start_date = timezone.now() - timedelta(days=days)
+
+        sales = Sale.objects.filter(created_at__gte=start_date)
+        total_revenue_all = sales.aggregate(total=Coalesce(Sum('total_amount'), Decimal('0')))['total']
+
+        sales_by_method = sales.values('payment_method').annotate(
+            total_sales=Count('id'),
+            total_revenue=Sum('total_amount')
+        ).order_by('-total_revenue')
+
+        result = []
+        for method in sales_by_method:
+            revenue = method['total_revenue'] or Decimal('0')
+            percentage = (revenue / total_revenue_all * 100) if total_revenue_all > 0 else Decimal('0')
+            result.append({
+                'payment_method': method['payment_method'],
+                'total_sales': method['total_sales'],
+                'total_revenue': revenue,
+                'percentage': round(percentage, 2),
+            })
+
+        serializer = SalesByPaymentMethodSerializer(result, many=True)
+        return Response(serializer.data)
+
+
+class InventoryValueView(APIView):
+    """
+    Inventory valuation report by store.
+    Shows total value of inventory based on base prices.
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        store_id = request.query_params.get('store_id')
+
+        queryset = StockLevel.objects.select_related('store', 'sku')
+
+        if store_id:
+            queryset = queryset.filter(store_id=store_id)
+
+        # Group by store
+        stores = Store.objects.all()
+        if store_id:
+            stores = stores.filter(id=store_id)
+
+        result = []
+        for store in stores:
+            stock_levels = queryset.filter(store=store)
+
+            total_items = stock_levels.aggregate(total=Coalesce(Sum('quantity'), 0))['total']
+            total_skus = stock_levels.count()
+
+            # Calculate total value
+            total_value = Decimal('0')
+            for sl in stock_levels:
+                total_value += sl.quantity * sl.sku.base_price
+
+            result.append({
+                'store_id': store.id,
+                'store_name': store.name,
+                'total_items': total_items,
+                'total_skus': total_skus,
+                'total_value': total_value,
+            })
+
+        serializer = InventoryValueSerializer(result, many=True)
+        return Response(serializer.data)
+
+
+class InventoryDetailView(APIView):
+    """
+    Detailed inventory listing.
+
+    Query params:
+    - store_id: Filter by store
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        store_id = request.query_params.get('store_id')
+
+        queryset = StockLevel.objects.select_related('store', 'sku', 'sku__product')
+
+        if store_id:
+            queryset = queryset.filter(store_id=store_id)
+
+        result = []
+        for sl in queryset.order_by('store__name', 'sku__product__name'):
+            result.append({
+                'sku_id': sl.sku.id,
+                'sku_code': sl.sku.sku_code,
+                'product_name': sl.sku.product.name,
+                'store_name': sl.store.name,
+                'quantity': sl.quantity,
+                'unit_price': sl.sku.base_price,
+                'total_value': sl.quantity * sl.sku.base_price,
+            })
+
+        serializer = InventoryItemSerializer(result, many=True)
+        return Response(serializer.data)
+
+
+class LowStockReportView(APIView):
+    """
+    Low stock alerts report.
+
+    Query params:
+    - threshold: Stock level threshold (default: 10)
+    - critical_threshold: Critical level threshold (default: 5)
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        threshold = int(request.query_params.get('threshold', 10))
+        critical_threshold = int(request.query_params.get('critical_threshold', 5))
+
+        low_stock = StockLevel.objects.filter(
+            quantity__lte=threshold
+        ).select_related('store', 'sku', 'sku__product').order_by('quantity')
+
+        result = []
+        for sl in low_stock:
+            if sl.quantity == 0:
+                status = 'OUT_OF_STOCK'
+            elif sl.quantity <= critical_threshold:
+                status = 'CRITICAL'
+            else:
+                status = 'LOW'
+
+            result.append({
+                'sku_id': sl.sku.id,
+                'sku_code': sl.sku.sku_code,
+                'product_name': sl.sku.product.name,
+                'store_id': sl.store.id,
+                'store_name': sl.store.name,
+                'current_quantity': sl.quantity,
+                'threshold': threshold,
+                'status': status,
+            })
+
+        serializer = LowStockAlertSerializer(result, many=True)
+        return Response({
+            'threshold': threshold,
+            'critical_threshold': critical_threshold,
+            'total_alerts': len(result),
+            'out_of_stock': len([r for r in result if r['status'] == 'OUT_OF_STOCK']),
+            'critical': len([r for r in result if r['status'] == 'CRITICAL']),
+            'low': len([r for r in result if r['status'] == 'LOW']),
+            'items': serializer.data,
+        })
+
+
+class StockMovementReportView(APIView):
+    """
+    Stock movement summary report.
+
+    Query params:
+    - days: Number of days to look back (default: 7)
+    - movement_type: Filter by type (SALE, PURCHASE, RETURN, ADJUSTMENT)
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        days = int(request.query_params.get('days', 7))
+        movement_type = request.query_params.get('movement_type')
+        start_date = timezone.now() - timedelta(days=days)
+
+        queryset = StockMovement.objects.filter(timestamp__gte=start_date)
+
+        if movement_type:
+            queryset = queryset.filter(movement_type=movement_type)
+
+        movements = queryset.annotate(
+            date=TruncDate('timestamp')
+        ).values('date', 'movement_type').annotate(
+            total_movements=Count('id'),
+            total_quantity=Sum('quantity_changed')
+        ).order_by('-date', 'movement_type')
+
+        result = []
+        for m in movements:
+            result.append({
+                'date': m['date'],
+                'movement_type': m['movement_type'],
+                'total_movements': m['total_movements'],
+                'total_quantity': m['total_quantity'],
+            })
+
+        serializer = StockMovementReportSerializer(result, many=True)
+        return Response(serializer.data)
+
+
+class DashboardView(APIView):
+    """
+    Dashboard summary with key metrics.
+    Provides a quick overview of the business.
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        now = timezone.now()
+        today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        week_start = now - timedelta(days=7)
+        month_start = now - timedelta(days=30)
+
+        # Today's sales
+        today_sales = Sale.objects.filter(created_at__gte=today_start)
+        today_revenue = today_sales.aggregate(total=Coalesce(Sum('total_amount'), Decimal('0')))['total']
+        today_count = today_sales.count()
+
+        # This week's sales
+        week_sales = Sale.objects.filter(created_at__gte=week_start)
+        week_revenue = week_sales.aggregate(total=Coalesce(Sum('total_amount'), Decimal('0')))['total']
+        week_count = week_sales.count()
+
+        # This month's sales
+        month_sales = Sale.objects.filter(created_at__gte=month_start)
+        month_revenue = month_sales.aggregate(total=Coalesce(Sum('total_amount'), Decimal('0')))['total']
+        month_count = month_sales.count()
+
+        # Low stock count
+        low_stock_count = StockLevel.objects.filter(quantity__lte=10).count()
+        out_of_stock_count = StockLevel.objects.filter(quantity=0).count()
+
+        # Total inventory value
+        total_inventory_value = Decimal('0')
+        for sl in StockLevel.objects.select_related('sku'):
+            total_inventory_value += sl.quantity * sl.sku.base_price
+
+        # Pending purchase orders
+        from suppliers.models import PurchaseOrder
+        pending_orders = PurchaseOrder.objects.filter(status='PENDING').count()
+
+        return Response({
+            'today': {
+                'sales_count': today_count,
+                'revenue': today_revenue,
+            },
+            'this_week': {
+                'sales_count': week_count,
+                'revenue': week_revenue,
+            },
+            'this_month': {
+                'sales_count': month_count,
+                'revenue': month_revenue,
+            },
+            'inventory': {
+                'total_value': total_inventory_value,
+                'low_stock_alerts': low_stock_count,
+                'out_of_stock': out_of_stock_count,
+            },
+            'pending_purchase_orders': pending_orders,
+            'stores_count': Store.objects.count(),
+            'products_count': Product.objects.count(),
+            'employees_count': Employee.objects.filter(is_active=True).count(),
+        })

--- a/backend/sales/admin.py
+++ b/backend/sales/admin.py
@@ -1,3 +1,59 @@
 from django.contrib import admin
+from .models import Sale, SaleLine, Receipt, Return, Refund
 
-# Register your models here.
+
+class SaleLineInline(admin.TabularInline):
+    model = SaleLine
+    extra = 0
+    readonly_fields = ('line_total',)
+
+    def line_total(self, obj):
+        return obj.quantity * obj.unit_price
+    line_total.short_description = 'Total'
+
+
+@admin.register(Sale)
+class SaleAdmin(admin.ModelAdmin):
+    list_display = ('id', 'store', 'register', 'cashier', 'total_amount', 'payment_method', 'created_at')
+    list_filter = ('store', 'payment_method', 'created_at')
+    search_fields = ('cashier__username', 'store__name')
+    ordering = ('-created_at',)
+    inlines = [SaleLineInline]
+    readonly_fields = ('created_at',)
+
+
+@admin.register(SaleLine)
+class SaleLineAdmin(admin.ModelAdmin):
+    list_display = ('sale', 'sku', 'quantity', 'unit_price', 'line_total')
+    list_filter = ('sale__store',)
+    search_fields = ('sku__sku_code', 'sku__product__name')
+
+    def line_total(self, obj):
+        return obj.quantity * obj.unit_price
+    line_total.short_description = 'Total'
+
+
+@admin.register(Receipt)
+class ReceiptAdmin(admin.ModelAdmin):
+    list_display = ('receipt_number', 'sale', 'sale_date')
+    search_fields = ('receipt_number',)
+    ordering = ('-sale__created_at',)
+
+    def sale_date(self, obj):
+        return obj.sale.created_at
+    sale_date.short_description = 'Date'
+    sale_date.admin_order_field = 'sale__created_at'
+
+
+@admin.register(Return)
+class ReturnAdmin(admin.ModelAdmin):
+    list_display = ('id', 'original_sale', 'reason', 'created_at')
+    list_filter = ('created_at',)
+    search_fields = ('reason', 'original_sale__id')
+    ordering = ('-created_at',)
+
+
+@admin.register(Refund)
+class RefundAdmin(admin.ModelAdmin):
+    list_display = ('id', 'return_record', 'amount')
+    search_fields = ('return_record__id',)

--- a/backend/suppliers/admin.py
+++ b/backend/suppliers/admin.py
@@ -1,3 +1,35 @@
 from django.contrib import admin
+from .models import Supplier, PurchaseOrder, PurchaseOrderLine
 
-# Register your models here.
+
+class PurchaseOrderLineInline(admin.TabularInline):
+    model = PurchaseOrderLine
+    extra = 1
+
+
+@admin.register(Supplier)
+class SupplierAdmin(admin.ModelAdmin):
+    list_display = ('name', 'contact_info')
+    search_fields = ('name', 'contact_info')
+    ordering = ('name',)
+
+
+@admin.register(PurchaseOrder)
+class PurchaseOrderAdmin(admin.ModelAdmin):
+    list_display = ('id', 'supplier', 'status', 'created_at', 'line_count')
+    list_filter = ('status', 'supplier', 'created_at')
+    search_fields = ('supplier__name',)
+    ordering = ('-created_at',)
+    inlines = [PurchaseOrderLineInline]
+    readonly_fields = ('created_at',)
+
+    def line_count(self, obj):
+        return obj.lines.count()
+    line_count.short_description = 'Items'
+
+
+@admin.register(PurchaseOrderLine)
+class PurchaseOrderLineAdmin(admin.ModelAdmin):
+    list_display = ('purchase_order', 'sku', 'quantity')
+    list_filter = ('purchase_order__supplier',)
+    search_fields = ('sku__sku_code', 'sku__product__name')

--- a/backend/suppliers/serializers.py
+++ b/backend/suppliers/serializers.py
@@ -1,0 +1,71 @@
+from rest_framework import serializers
+from .models import Supplier, PurchaseOrder, PurchaseOrderLine
+from products.serializers import SKUSerializer
+
+
+class SupplierSerializer(serializers.ModelSerializer):
+    """Serializer for Supplier model."""
+
+    class Meta:
+        model = Supplier
+        fields = ['id', 'name', 'contact_info']
+        read_only_fields = ['id']
+
+
+class PurchaseOrderLineSerializer(serializers.ModelSerializer):
+    """Serializer for PurchaseOrderLine model."""
+
+    sku_details = SKUSerializer(source='sku', read_only=True)
+
+    class Meta:
+        model = PurchaseOrderLine
+        fields = ['id', 'purchase_order', 'sku', 'sku_details', 'quantity']
+        read_only_fields = ['id']
+
+
+class PurchaseOrderLineCreateSerializer(serializers.ModelSerializer):
+    """Serializer for creating PurchaseOrderLine."""
+
+    class Meta:
+        model = PurchaseOrderLine
+        fields = ['sku', 'quantity']
+
+
+class PurchaseOrderSerializer(serializers.ModelSerializer):
+    """Serializer for PurchaseOrder model (read)."""
+
+    supplier_name = serializers.CharField(source='supplier.name', read_only=True)
+    lines = PurchaseOrderLineSerializer(many=True, read_only=True)
+    total_items = serializers.SerializerMethodField()
+
+    class Meta:
+        model = PurchaseOrder
+        fields = ['id', 'supplier', 'supplier_name', 'status', 'created_at', 'lines', 'total_items']
+        read_only_fields = ['id', 'created_at']
+
+    def get_total_items(self, obj):
+        return sum(line.quantity for line in obj.lines.all())
+
+
+class PurchaseOrderCreateSerializer(serializers.ModelSerializer):
+    """Serializer for creating PurchaseOrder with lines."""
+
+    lines = PurchaseOrderLineCreateSerializer(many=True)
+
+    class Meta:
+        model = PurchaseOrder
+        fields = ['supplier', 'status', 'lines']
+
+    def validate_lines(self, value):
+        if not value:
+            raise serializers.ValidationError("At least one line item is required")
+        return value
+
+    def create(self, validated_data):
+        lines_data = validated_data.pop('lines')
+        purchase_order = PurchaseOrder.objects.create(**validated_data)
+
+        for line_data in lines_data:
+            PurchaseOrderLine.objects.create(purchase_order=purchase_order, **line_data)
+
+        return purchase_order

--- a/backend/suppliers/views.py
+++ b/backend/suppliers/views.py
@@ -1,3 +1,141 @@
-from django.shortcuts import render
+from rest_framework import viewsets, status, filters
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from django_filters.rest_framework import DjangoFilterBackend
+from django.db import transaction
 
-# Create your views here.
+from .models import Supplier, PurchaseOrder, PurchaseOrderLine
+from .serializers import (
+    SupplierSerializer,
+    PurchaseOrderSerializer,
+    PurchaseOrderCreateSerializer,
+    PurchaseOrderLineSerializer
+)
+from inventory.models import StockLevel, StockMovement
+from accounts.permissions import IsManagerOrReadOnly
+
+
+class SupplierViewSet(viewsets.ModelViewSet):
+    """
+    ViewSet for managing suppliers.
+
+    Permissions:
+    - Managers: Full CRUD access
+    - Cashiers: Read-only access
+    """
+    queryset = Supplier.objects.all()
+    serializer_class = SupplierSerializer
+    permission_classes = [IsManagerOrReadOnly]
+    filter_backends = [filters.SearchFilter, filters.OrderingFilter]
+    search_fields = ['name', 'contact_info']
+    ordering_fields = ['name']
+    ordering = ['name']
+
+
+class PurchaseOrderViewSet(viewsets.ModelViewSet):
+    """
+    ViewSet for managing purchase orders.
+
+    Supports creating purchase orders with line items,
+    and receiving orders to update inventory.
+    """
+    queryset = PurchaseOrder.objects.all().select_related('supplier').prefetch_related('lines', 'lines__sku')
+    permission_classes = [IsManagerOrReadOnly]
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
+    filterset_fields = ['supplier', 'status']
+    ordering_fields = ['created_at', 'status']
+    ordering = ['-created_at']
+
+    def get_serializer_class(self):
+        if self.action == 'create':
+            return PurchaseOrderCreateSerializer
+        return PurchaseOrderSerializer
+
+    @action(detail=True, methods=['post'])
+    @transaction.atomic
+    def receive(self, request, pk=None):
+        """
+        Receive a purchase order and update inventory.
+
+        Request body:
+        {
+            "store_id": 1  # Store to receive inventory into
+        }
+        """
+        purchase_order = self.get_object()
+
+        if purchase_order.status == 'RECEIVED':
+            return Response(
+                {'error': 'Purchase order has already been received'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        store_id = request.data.get('store_id')
+        if not store_id:
+            return Response(
+                {'error': 'store_id is required'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # Update inventory for each line item
+        for line in purchase_order.lines.all():
+            stock_level, created = StockLevel.objects.get_or_create(
+                store_id=store_id,
+                sku=line.sku,
+                defaults={'quantity': 0}
+            )
+
+            stock_level.quantity += line.quantity
+            stock_level.save()
+
+            # Record stock movement
+            StockMovement.objects.create(
+                stock_level=stock_level,
+                movement_type='PURCHASE',
+                quantity_changed=line.quantity
+            )
+
+        # Update purchase order status
+        purchase_order.status = 'RECEIVED'
+        purchase_order.save()
+
+        return Response(
+            PurchaseOrderSerializer(purchase_order).data,
+            status=status.HTTP_200_OK
+        )
+
+    @action(detail=True, methods=['post'])
+    def cancel(self, request, pk=None):
+        """Cancel a purchase order."""
+        purchase_order = self.get_object()
+
+        if purchase_order.status == 'RECEIVED':
+            return Response(
+                {'error': 'Cannot cancel a received purchase order'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        purchase_order.status = 'CANCELLED'
+        purchase_order.save()
+
+        return Response(
+            PurchaseOrderSerializer(purchase_order).data,
+            status=status.HTTP_200_OK
+        )
+
+    @action(detail=False, methods=['get'])
+    def pending(self, request):
+        """Get all pending purchase orders."""
+        pending_orders = self.get_queryset().filter(status='PENDING')
+        serializer = self.get_serializer(pending_orders, many=True)
+        return Response(serializer.data)
+
+
+class PurchaseOrderLineViewSet(viewsets.ModelViewSet):
+    """ViewSet for managing purchase order lines."""
+    queryset = PurchaseOrderLine.objects.all().select_related('purchase_order', 'sku', 'sku__product')
+    serializer_class = PurchaseOrderLineSerializer
+    permission_classes = [IsManagerOrReadOnly]
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ['purchase_order']


### PR DESCRIPTION
 ## Summary

  - Configure Django admin for all models (accounts, products, inventory, sales, suppliers)
  - Add token blacklist for JWT logout functionality
  - Fix products views to use existing SKU model instead of missing Category
  - Create suppliers module with views, serializers, and purchase order management
  - Add reports module with dashboard and analytics endpoints
  - Register all ViewSets in URL router

  ## New API Endpoints

  ### Suppliers
  - `GET/POST /api/suppliers/` - List/Create suppliers
  - `GET/POST /api/purchase-orders/` - Manage purchase orders
  - `POST /api/purchase-orders/{id}/receive/` - Receive PO and update inventory
  - `POST /api/purchase-orders/{id}/cancel/` - Cancel pending PO

  ### Reports
  - `GET /api/reports/dashboard/` - Business overview dashboard
  - `GET /api/reports/sales/summary/` - Sales summary by period
  - `GET /api/reports/sales/daily/` - Daily sales breakdown
  - `GET /api/reports/sales/by-store/` - Sales by store
  - `GET /api/reports/sales/by-employee/` - Sales by employee
  - `GET /api/reports/products/top-selling/` - Top selling products
  - `GET /api/reports/inventory/value/` - Inventory valuation
  - `GET /api/reports/inventory/low-stock/` - Low stock alerts

  ## Test plan
  - [ ] Verify all API endpoints return correct data
  - [ ] Test admin panel access and CRUD operations
  - [ ] Verify reports show accurate calculations